### PR TITLE
Fix error when buffer has non-serializable vars

### DIFF
--- a/autoload/ddu/source/buffer.vim
+++ b/autoload/ddu/source/buffer.vim
@@ -1,0 +1,14 @@
+function! ddu#source#buffer#getbufinfo() abort
+  return {
+  \  'currentDir': getcwd(),
+  \  'currentBufNr': bufnr('%'),
+  \  'alternateBufNr': bufnr('#'),
+  \  'buffers': map(getbufinfo(), {_, buf -> {
+  \    'bufnr': buf['bufnr'],
+  \    'changed': buf['changed'],
+  \    'lastused': buf['lastused'],
+  \    'listed': buf['listed'],
+  \    'name': buf['name'],
+  \  }}),
+  \}
+endfunction


### PR DESCRIPTION
If buffer has non-serializable vars (eg. `Funcref`), calling `fn.getbufinfo(denops)` is failure.

Therefore, filtering values of `getbufinfo()` by Vim function.

Fixes #4