### PR TITLE
Fix display buffer names

### DIFF
--- a/autoload/ddu/source/buffer.vim
+++ b/autoload/ddu/source/buffer.vim
@@ -9,5 +9,16 @@ function! ddu#source#buffer#getbufinfo() abort
   \    'listed': buf['listed'],
   \    'name': buf['name'],
   \  }}),
+  \  'termList': s:termList(),
   \}
 endfunction
+
+if exists('*term_list')
+  function! s:termList() abort
+    return term_list()
+  endfunction
+else
+  function! s:termList() abort
+    return []
+  endfunction
+endif

--- a/denops/@ddu-sources/buffer.ts
+++ b/denops/@ddu-sources/buffer.ts
@@ -32,7 +32,6 @@ type BufInfo = {
 
 type GetBufInfoReturn = {
   currentDir: string;
-  currentBufNr: number;
   alternateBufNr: number;
   buffers: BufInfo[];
 };


### PR DESCRIPTION
Fixes #9, #10 and #11.

- No name buffers are displayed as `[No Name]`.
- Files under the current directory are displayed with relative paths.
- Other files are displayed with absolute paths.
- Terminal buffers or URL name buffers are displayed as is.

Below are the side changes.

- Add `isTerminal` to `ActionData`.
