### PR TITLE
Add "bufType" action data for each buffer

### DIFF
--- a/autoload/ddu/source/buffer.vim
+++ b/autoload/ddu/source/buffer.vim
@@ -9,16 +9,5 @@ function! ddu#source#buffer#getbufinfo() abort
   \    'listed': buf['listed'],
   \    'name': buf['name'],
   \  }}),
-  \  'termList': s:termList(),
   \}
 endfunction
-
-if exists('*term_list')
-  function! s:termList() abort
-    return term_list()
-  endfunction
-else
-  function! s:termList() abort
-    return []
-  endfunction
-endif

--- a/denops/@ddu-sources/buffer.ts
+++ b/denops/@ddu-sources/buffer.ts
@@ -40,7 +40,6 @@ type GetBufInfoReturn = {
   currentDir: string;
   alternateBufNr: number;
   buffers: BufInfo[];
-  termList: number[];
 };
 
 type Params = {

--- a/denops/@ddu-sources/buffer.ts
+++ b/denops/@ddu-sources/buffer.ts
@@ -150,19 +150,20 @@ export class Source extends BaseSource<Params> {
     delete: async ({ denops, items }: ActionArguments<Params>) => {
       try {
         for (const item of items) {
-          const existed = await fn.bufexists(denops, item.action.bufNr);
+          const action = item.action as ActionData;
+          const existed = await fn.bufexists(denops, action.bufNr);
           if (!existed) {
             throw new Error(
-              `the buffer doesn't exist> ${item.action.bufNr}: ${item.action.path}`,
+              `the buffer doesn't exist> ${action.bufNr}: ${action.path}`,
             );
           }
 
-          const bufinfo = await denops.call("getbufinfo", item.action.bufNr);
+          const bufinfo = await denops.call("getbufinfo", action.bufNr);
           if (bufinfo.length && bufinfo[0].changed === 0) {
-            await denops.cmd(`bwipeout ${item.action.bufNr}`);
+            await denops.cmd(`bwipeout ${action.bufNr}`);
           } else {
             throw new Error(
-              `can't delete the buffer> ${item.action.bufNr}: ${item.action.path}`,
+              `can't delete the buffer> ${action.bufNr}: ${action.path}`,
             );
           }
         }

--- a/denops/@ddu-sources/buffer.ts
+++ b/denops/@ddu-sources/buffer.ts
@@ -69,14 +69,13 @@ export class Source extends BaseSource<Params> {
       curnr_: number,
       altnr_: number,
       currentDir: string,
-      termSet: Set<number>,
     ): Promise<ActionInfo> => {
       const { bufnr, changed, name } = bufinfo;
       const uBufType = await fn.getbufvar(args.denops, bufnr, "&buftype");
       const bufType = (typeof(uBufType) == 'string' )? uBufType:'';
 
       // Only vim has termSet, Only neovim has name "term://...".
-      const isTerminal = termSet.has(bufnr) || name.startsWith("term://");
+      const isTerminal = bufType === "terminal"
 
       // Windows absolute paths are recognized as URL.
       const isPathName = !isTerminal && (!isURL(name) || isAbsolute(name));
@@ -117,12 +116,9 @@ export class Source extends BaseSource<Params> {
         currentDir,
         alternateBufNr,
         buffers,
-        termList,
       } = await args.denops.call(
         "ddu#source#buffer#getbufinfo",
       ) as GetBufInfoReturn;
-      const termSet = new Set(termList);
-
       return await Promise.all(buffers.filter((b) => b.listed).sort((a, b) => {
         if (args.sourceParams.orderby === "desc") {
           if (a.bufnr === currentBufNr) return 1;
@@ -132,7 +128,7 @@ export class Source extends BaseSource<Params> {
 
         return a.lastused - b.lastused;
       }).map(async (b) =>
-        await getActioninfo(b, currentBufNr, alternateBufNr, currentDir, termSet)
+        await getActioninfo(b, currentBufNr, alternateBufNr, currentDir)
       ));
     };
 


### PR DESCRIPTION
I want to filter buffers by 'buftype' option, but the action has no data.
So I propose that add new data "bufType" for each item.

In addition:

- I made the data type of item.action explicit.
- Using the new 'bufType' to determine the terminal.
