### PR TITLE
Fix BigInt convertion

### DIFF
--- a/denops/@ddu-sources/buffer.ts
+++ b/denops/@ddu-sources/buffer.ts
@@ -10,7 +10,7 @@ import { fn } from "https://deno.land/x/ddu_vim@v3.10.3/deps.ts";
 import {
   isAbsolute,
   relative,
-} from "https://deno.land/std@0.219.1/path/mod.ts#^";
+} from "https://deno.land/std@0.221.0/path/mod.ts#^";
 import { isURL } from "https://deno.land/x/is_url@v1.0.1/mod.ts";
 
 type ActionData = {
@@ -123,10 +123,10 @@ export class Source extends BaseSource<Params> {
           if (args.sourceParams.orderby === "desc") {
             if (a.bufnr === currentBufNr) return 1;
             if (b.bufnr === currentBufNr) return -1;
-            return Number(b.lastused - a.lastused);
+            return Number(BigInt(b.lastused) - BigInt(a.lastused));
           }
 
-          return Number(a.lastused - b.lastused);
+          return Number(BigInt(a.lastused) - BigInt(b.lastused));
         }).map(async (b) =>
           await getActioninfo(b, currentBufNr, alternateBufNr, currentDir)
         ),


### PR DESCRIPTION
I have fixed `BigInt` conversion again.

```
[ddu] source: buffer "gather()" failed
[ddu] Cannot mix BigInt and other types, use explicit conversions
[ddu] TypeError: Cannot mix BigInt and other types, use explicit conversions^@    at file:///home/kyoh86/.local/share/nvim/lazy/ddu-source-buffer/denops/@ddu-sources/buffer.ts:129:35^@    at Array.sort (<anonymous>)^@    at getBuflist (file:///home/kyoh86/.local/share/nvim/lazy/ddu-source-buffer/denops/@ddu-sources/buffer.ts:122:41)^@    at eventLoopTick (ext:core/01_core.js:169:7)^@    at async Object.start (file:///home/kyoh86/.local/share/nvim/lazy/ddu-source-buffer/denops/@ddu-sources/buffer.ts:139:11)
```